### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM ocaml/opam:ubuntu-20.10-ocaml-4.11
-
+FROM ocaml/opam:ubuntu-lts-ocaml-4.13
 USER root
-
-RUN apt-get update && apt-get install -y m4
-
+RUN apt-get update
+RUN apt-get install -y m4
+RUN apt-get install -y tzdata
 RUN opam install ounit2 -y
-RUN opam install batteries -y
-RUN opam install core -y
 RUN opam install qcheck -y


### PR DESCRIPTION
Follow up to #1:
Added tzdata package: required to correctly resolve timezones for hidden tests
Updated base image: Use the latest OCaml version
Remove batteries and core: Saves 1GB image size; depending on the level of backwards compatibility desired in these images, this may have to be undone.