### PR TITLE
Add GitHub Action to automatically build and push the image

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,30 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ls1tum/artemis-ocaml-docker:${{ github.sha }}


### PR DESCRIPTION
Since building and pushing is more effort than it has to be, here is a github action to automate the process.
This builds the dockerfile on every commit and pushes it as a new tag, the commit hash.

Post-merge step: set the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets